### PR TITLE
Explore options for simplifying Reservoirs Hosted Feature Layer

### DIFF
--- a/server/services/definition/05/riskQueries.json
+++ b/server/services/definition/05/riskQueries.json
@@ -26,6 +26,11 @@
     "outFields": "Risk_band"
   },
   {
+    "key": "wetReservoirs",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Reservoir_Flood_Extents_Merged_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
     "key": "surfaceWaterCC",
     "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_CCSW1_0mm_NON_PRODUCTION/FeatureServer/0",
     "outFields": "Risk_band"

--- a/server/services/definition/06/riskQueries.json
+++ b/server/services/definition/06/riskQueries.json
@@ -22,7 +22,12 @@
   },
   {
     "key": "dryReservoirs",
-    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Reservoir_Flood_Extents_Merged_NON_PRODUCTION/FeatureServer/0",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Reservoir_Flood_Extents_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "wetReservoirs",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Reservoir_Flood_Extents_NON_PRODUCTION/FeatureServer/1",
     "outFields": "Risk_band"
   },
   {

--- a/server/services/definition/06/riversSeaDepth.json
+++ b/server/services/definition/06/riversSeaDepth.json
@@ -1,0 +1,32 @@
+[
+  {
+    "key": "riversAndSeaDepth200mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_200mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "riversAndSeaDepth300mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_300mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "riversAndSeaDepth600mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_600mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "riversAndSeaCCDepth200mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_CCRS1_200mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "riversAndSeaCCDepth300mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_CCRS1_300mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "riversAndSeaCCDepth600mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Rivers_and_Sea_CCRS1_600mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  }
+]

--- a/server/services/definition/06/surfaceWaterDepth.json
+++ b/server/services/definition/06/surfaceWaterDepth.json
@@ -1,0 +1,32 @@
+[
+  {
+    "key": "surfaceWaterDepth200mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_200mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "surfaceWaterDepth300mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_300mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "surfaceWaterDepth600mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_600mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "surfaceWaterCCDepth200mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_CCSW1_200mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "surfaceWaterCCDepth300mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_CCSW1_300mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  },
+  {
+    "key": "surfaceWaterCCDepth600mm",
+    "url": "https://services1.arcgis.com/JZM7qJpmv7vJ0Hzx/arcgis/rest/services/Risk_of_Flooding_from_Surface_Water_Depth_CCSW1_600mm_NON_PRODUCTION/FeatureServer/0",
+    "outFields": "Risk_band"
+  }
+]

--- a/server/services/processReservoirRisk.js
+++ b/server/services/processReservoirRisk.js
@@ -1,16 +1,17 @@
+const getReservoirMapping = function (item) {
+  return {
+    reservoirName: item.attributes.reservoir ? item.attributes.reservoir : item.attributes.RESERVOIR,
+    location: item.attributes.ngr ? item.attributes.ngr : item.attributes.NGR,
+    riskDesignation: item.attributes.risk_designation ? item.attributes.risk_designation : item.attributes.RISK_DESIGNATION,
+    undertaker: item.attributes.undertaker ? item.attributes.undertaker : item.attributes.UNDERTAKER,
+    leadLocalFloodAuthority: item.attributes.llfa_name ? item.attributes.llfa_name : item.attributes.LLFA_NAME,
+    comments: item.attributes.comments ? item.attributes.comments : item.attributes.COMMENTS
+  }
+}
 function getReservoirWetRisk (riskQueryResult) {
   let reservoirWetRisk
   if (riskQueryResult.wetReservoirs?.length > 0) {
-    reservoirWetRisk = riskQueryResult.wetReservoirs.map(function (item) {
-      return {
-        reservoirName: item.attributes.RESERVOIR,
-        location: item.attributes.NGR,
-        riskDesignation: item.attributes.RISK_DESIGNATION,
-        undertaker: item.attributes.UNDERTAKER,
-        leadLocalFloodAuthority: item.attributes.LLFA_NAME,
-        comments: item.attributes.COMMENTS
-      }
-    })
+    reservoirWetRisk = riskQueryResult.wetReservoirs.map(getReservoirMapping)
   } else {
     reservoirWetRisk = riskQueryResult.wetReservoirs
   }
@@ -20,16 +21,7 @@ exports.getReservoirWetRisk = getReservoirWetRisk
 function getReservoirDryRisk (riskQueryResult) {
   let reservoirDryRisk
   if (riskQueryResult.dryReservoirs?.length > 0) {
-    reservoirDryRisk = riskQueryResult.dryReservoirs.map(function (item) {
-      return {
-        reservoirName: item.attributes.reservoir,
-        location: item.attributes.ngr,
-        riskDesignation: item.attributes.risk_designation,
-        undertaker: item.attributes.undertaker,
-        leadLocalFloodAuthority: item.attributes.llfa_name,
-        comments: item.attributes.comments
-      }
-    })
+    reservoirDryRisk = riskQueryResult.dryReservoirs.map(getReservoirMapping)
   } else {
     reservoirDryRisk = riskQueryResult.dryReservoirs
   }

--- a/server/services/riskQuery.js
+++ b/server/services/riskQuery.js
@@ -24,7 +24,7 @@ function loadRiskQueries () {
 function checkResult (result, query) {
   return new Promise((resolve, _reject) => {
     if (result.error) {
-      console.log('Error: %s', result.error.message)
+      console.log('Error: %s\n', result.error.message)
       throw new Error(`${result.error.code}: ${result.error.message}`)
     }
     if (config.performanceLogging) {
@@ -131,7 +131,7 @@ const runQueries = async (x, y, queries) => {
       if (!err) {
         err = new Error(`${promiseresult.reason}`, { cause: queries[index] })
       }
-      console.log(`${promiseresult.reason} : %s`, JSON.stringify(queries[index]))
+      console.log(`${promiseresult.reason} : %s\n`, JSON.stringify(queries[index]))
     } else {
       results[index] = promiseresult.value
     }
@@ -172,7 +172,7 @@ async function externalQueries (x, y, queries) {
     results.forEach((result, index) => {
       if (queries[index].esriCall) {
         if (!((result.features) || (result.layers))) {
-          console.log('Error: Invalid response for %s', queries[index].key)
+          console.log('Error: Invalid response for %s\n', queries[index].key)
           console.log(result)
           throw new Error(`Invalid response for ${queries[index].key}`)
         }
@@ -192,8 +192,8 @@ async function externalQueries (x, y, queries) {
       }
     })
     if (config.performanceLogging) {
-      console.log('{"TokenRefreshTime" : %d}', tokenRefreshTime)
-      console.log(JSON.stringify(allPerfData))
+      console.log('{"TokenRefreshTime" : %d}\n', tokenRefreshTime)
+      console.log(JSON.stringify(allPerfData, null, '\t'))
     }
   } catch (err) {
     const url = err.cause ? err.cause.url : ''


### PR DESCRIPTION
The CYLTFR application currently uses a merged version of the Reservoirs wet/dry scenario data when querying. Following the data automation work that we have recently completed, things would be simpler if we could simplify the steps required to create this dataset.

In order the create the merged layer, we have to do 2 additional steps - merging wet and dry, followed by a pairwise dissolve. This was done to resolve performance issues when querying the original reservoirs data when hosted in ArcGIS Online.

We now have some more time to see if we can use original data without additional processing. 